### PR TITLE
Fix auth, HTML parsing, critical bugs, and code quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 TODO.md
 .env
+.venv/
 *.json
 *.csv
 publish.sh

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-line_length = 88
+line_length = 79
 multi_line_output = 3
 include_trailing_comma = True
 known_third_party = celery,django,environ,pyquery,pytz,redis,requests,rest_framework

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,23 +1,41 @@
-import os 
+import os
 import sys
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
+
+PACKAGE_PARENT = ".."
+SCRIPT_DIR = os.path.dirname(
+    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__)))
+)
 sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
-from rich import print 
-from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter      
-import pandas as pd 
+import pandas as pd
+from rich import print
+
+from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter
+
 
 def test_keyword_to_url():
-    res = ScrapeGithubUrl._keyword_to_url(page_num=1, keyword='machine learning', 
-                        type="Users", sort_by='followers')
+    res = ScrapeGithubUrl._keyword_to_url(
+        page_num=1,
+        keyword="machine learning",
+        search_type="Users",
+        sort_by="followers",
+    )
 
-    assert res == "https://github.com/search?o=desc&p=1&q=machine+learning&s=followers&type=Users"
+    assert (
+        res
+        == "https://github.com/search?o=desc&p=1&q=machine+learning&s=followers&type=Users"
+    )
+
 
 def test_scrape_top_repo_url_multiple_pages():
-    res = ScrapeGithubUrl('machine learning', 'Repositories', 'stars', 1, 3).scrape_top_repo_url_multiple_pages()
+    res = ScrapeGithubUrl(
+        "machine learning", "Repositories", "stars", 1, 3
+    ).scrape_top_repo_url_multiple_pages()
+
 
 def test_get_all_contributor_profiles():
-    urls = ["https://api.github.com/users/jakevdp",
-            "https://api.github.com/users/fuglede"]
+    urls = [
+        "https://api.github.com/users/jakevdp",
+        "https://api.github.com/users/fuglede",
+    ]
     res = UserProfileGetter(urls).get_all_user_profiles()
     assert isinstance(res, pd.DataFrame)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,5 +19,5 @@ def test_scrape_top_repo_url_multiple_pages():
 def test_get_all_contributor_profiles():
     urls = ["https://api.github.com/users/jakevdp",
             "https://api.github.com/users/fuglede"]
-    res = UserProfileGetter(urls).get_all_contributor_profiles()
+    res = UserProfileGetter(urls).get_all_user_profiles()
     assert isinstance(res, pd.DataFrame)

--- a/top_github_scraper/__init__.py
+++ b/top_github_scraper/__init__.py
@@ -1,2 +1,2 @@
-from .scrape_repo import get_top_repo_urls, get_top_repos, get_top_contributors
+from .scrape_repo import get_top_contributors, get_top_repo_urls, get_top_repos
 from .scrape_user import get_top_user_urls, get_top_users

--- a/top_github_scraper/auth.py
+++ b/top_github_scraper/auth.py
@@ -1,0 +1,60 @@
+import logging
+import os
+import subprocess
+from functools import lru_cache
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@lru_cache(maxsize=1)
+def get_github_auth():
+    """Returns (username, token) or (None, None). Cached after first call."""
+    username = os.getenv("GITHUB_USERNAME")
+    token = os.getenv("GITHUB_TOKEN")
+
+    # Fallback: get token from gh CLI
+    if not token:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                token = result.stdout.strip()
+        except FileNotFoundError:
+            pass
+
+    # Fallback: get username from gh CLI
+    if not username and token:
+        try:
+            result = subprocess.run(
+                ["gh", "api", "user", "-q", ".login"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                username = result.stdout.strip()
+        except FileNotFoundError:
+            pass
+
+    if not token:
+        logging.warning(
+            "You are using the GitHub API as an unauthenticated user. "
+            "Limited to 60 requests/hour. Set GITHUB_USERNAME/GITHUB_TOKEN "
+            "in .env or run `gh auth login`."
+        )
+
+    return username, token
+
+
+def get_auth():
+    """Returns auth tuple for requests, or None if unauthenticated."""
+    username, token = get_github_auth()
+    if token:
+        return (username or token, token)
+    return None

--- a/top_github_scraper/auth.py
+++ b/top_github_scraper/auth.py
@@ -25,7 +25,7 @@ def get_github_auth():
             )
             if result.returncode == 0:
                 token = result.stdout.strip()
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.SubprocessError):
             pass
 
     # Fallback: get username from gh CLI
@@ -39,7 +39,7 @@ def get_github_auth():
             )
             if result.returncode == 0:
                 username = result.stdout.strip()
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.SubprocessError):
             pass
 
     if not token:

--- a/top_github_scraper/scrape_repo.py
+++ b/top_github_scraper/scrape_repo.py
@@ -1,21 +1,18 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import List
 
 import pandas as pd
 import requests
-from dotenv import load_dotenv
 from rich import print
 from rich.progress import track
 from tqdm import tqdm
+
+from top_github_scraper.auth import get_auth
 from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter, isnotebook
-import logging
 
-load_dotenv()
-
-USERNAME = os.getenv("GITHUB_USERNAME")
-TOKEN = os.getenv("GITHUB_TOKEN")
 
 class RepoScraper:
     """Scrape information of repos and the
@@ -30,12 +27,13 @@ class RepoScraper:
 
         if isnotebook():
             for repo_url in tqdm(
-            self.repo_urls, desc="Scraping top GitHub repositories..."
+                self.repo_urls, desc="Scraping top GitHub repositories..."
             ):
                 top_repo_infos.append(self._get_repo_information(repo_url))
         else:
             for repo_url in track(
-                self.repo_urls, description="Scraping top GitHub repositories..."
+                self.repo_urls,
+                description="Scraping top GitHub repositories...",
             ):
                 top_repo_infos.append(self._get_repo_information(repo_url))
 
@@ -43,20 +41,22 @@ class RepoScraper:
 
     def _get_repo_information(self, repo_url: str):
         repo_info_url = f"https://api.github.com/repos{repo_url}"
-        http_response = requests.get(repo_info_url, auth=(USERNAME, TOKEN))
+        http_response = requests.get(repo_info_url, auth=get_auth())
         # Checking for a good response on HTTP get request.
         # An HTTP response of 200 indicates a successful response packet.
         if http_response.status_code != 200:
-            logging.error(f"You are getting a bad HTTP response when you are requesting info from this URL: {repo_info_url}")
+            logging.error(
+                f"You are getting a bad HTTP response when you are requesting info from this URL: {repo_info_url}"
+            )
         repo_info = http_response.json()
         info_to_scrape = ["stargazers_count", "forks_count"]
         repo_important_info = {}
         for info in info_to_scrape:
             repo_important_info[info] = repo_info[info]
 
-        repo_important_info[
-            "contributors"
-        ] = self._get_contributor_repo_of_one_repo(repo_url)
+        repo_important_info["contributors"] = (
+            self._get_contributor_repo_of_one_repo(repo_url)
+        )
 
         return repo_important_info
 
@@ -66,7 +66,7 @@ class RepoScraper:
         contributor_url = (
             f"https://api.github.com/repos{repo_url}/contributors"
         )
-        http_response = requests.get(contributor_url, auth=(USERNAME, TOKEN))
+        http_response = requests.get(contributor_url, auth=get_auth())
         # Return an empty dictionary if we encouter an error for a particular URL.
         # This will allow us to keep parsing the rest of the URLs we need to parse without erroring out.
         if http_response.status_code != 200:
@@ -141,22 +141,22 @@ class DataProcessor:
 
 def get_top_repo_urls(
     keyword: str,
-    sort_by: str='best_match', 
-    save_directory: str=".",
+    sort_by: str = "best_match",
+    save_directory: str = ".",
     start_page: int = 1,
     stop_page: int = 10,
 ):
     """Get the URLs of the repositories pop up when searching for a specific
     keyword on GitHub.
-    
+
     See PARAMETERs.md for a description of the parameters of this function
     """
     safe_keyword = keyword.replace(" ", "_")
-    try: 
+    try:
         Path(save_directory).mkdir(parents=True, exist_ok=True)
-        full_path = f'{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json'
+        full_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
         repo_urls = ScrapeGithubUrl(
-            keyword, 'Repositories', sort_by, start_page, stop_page
+            keyword, "Repositories", sort_by, start_page, stop_page
         ).scrape_top_repo_url_multiple_pages()
 
         with open(full_path, "w") as outfile:
@@ -164,32 +164,38 @@ def get_top_repo_urls(
         return repo_urls
     except Exception as e:
         print(e)
-        logging.error("""You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
-                      If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available.""")
+        logging.error(
+            """You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
+                      If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available."""
+        )
 
 
 def get_top_repos(
     keyword: int,
-    sort_by: str='best_match',
-    save_directory: str=".",
+    sort_by: str = "best_match",
+    save_directory: str = ".",
     max_n_top_contributors: int = 10,
     start_page: int = 1,
     stop_page: int = 10,
 ):
     """Get the information of the repositories pop up when searching for a specific
     keyword on GitHub.
-    
+
     See PARAMETERs.md for a description of the parameters of this function
     """
     safe_keyword = keyword.replace(" ", "_")
     try:
-        full_url_save_path = (
-            f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
-        )
+        full_url_save_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
         repo_save_path = f"{save_directory}/top_repo_info_{safe_keyword}_{start_page}_{stop_page}.json"
 
         if not Path(full_url_save_path).exists():
-            get_top_repo_urls(keyword=keyword, sort_by=sort_by, save_directory=save_directory, start_page=start_page, stop_page=stop_page)
+            get_top_repo_urls(
+                keyword=keyword,
+                sort_by=sort_by,
+                save_directory=save_directory,
+                start_page=start_page,
+                stop_page=stop_page,
+            )
         with open(full_url_save_path, "r") as infile:
             repo_urls = json.load(infile)
             top_repos = RepoScraper(
@@ -200,30 +206,31 @@ def get_top_repos(
             json.dump(top_repos, outfile)
         return top_repos
 
-    except Exception as e:  
+    except Exception as e:
         print(e)
-        logging.error("""You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
-                      If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available.""")
+        logging.error(
+            """You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
+                      If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available."""
+        )
+
 
 def get_top_contributors(
     keyword: int,
-    sort_by: str='best_match', 
+    sort_by: str = "best_match",
     max_n_top_contributors: int = 10,
     start_page: int = 1,
     stop_page: int = 10,
-    get_user_info_only: bool=True, 
-    save_directory: str=".",
+    get_user_info_only: bool = True,
+    save_directory: str = ".",
 ):
     """
     Get the information of the owners and contributors of the repositories pop up when searching for a specific
     keyword on GitHub.
-    
+
     See PARAMETERs.md for a description of the parameters of this function
     """
     safe_keyword = keyword.replace(" ", "_")
-    full_repo_save_path = (
-        f"{save_directory}/top_repo_info_{safe_keyword}_{start_page}_{stop_page}.json"
-    )
+    full_repo_save_path = f"{save_directory}/top_repo_info_{safe_keyword}_{start_page}_{stop_page}.json"
     user_save_path = f"{save_directory}/top_contributor_info_{safe_keyword}_{start_page}_{stop_page}.csv"
     if not Path(full_repo_save_path).exists():
         get_top_repos(
@@ -232,18 +239,20 @@ def get_top_contributors(
             max_n_top_contributors=max_n_top_contributors,
             start_page=start_page,
             stop_page=stop_page,
-            save_directory=save_directory
+            save_directory=save_directory,
         )
     with open(full_repo_save_path, "r") as infile:
         repo_info = json.load(infile)
         repo_info = DataProcessor(repo_info).process()
-        urls = repo_info['url']
+        urls = repo_info["url"]
         top_users = UserProfileGetter(urls).get_all_user_profiles()
         if get_user_info_only:
             top_users.to_csv(user_save_path)
             return top_users
         else:
             repo_and_top_users = pd.concat([repo_info, top_users], axis=1)
-            repo_and_top_users = repo_and_top_users.loc[:,~repo_and_top_users.columns.duplicated()]
+            repo_and_top_users = repo_and_top_users.loc[
+                :, ~repo_and_top_users.columns.duplicated()
+            ]
             repo_and_top_users.to_csv(user_save_path)
             return repo_and_top_users

--- a/top_github_scraper/scrape_repo.py
+++ b/top_github_scraper/scrape_repo.py
@@ -11,7 +11,11 @@ from rich.progress import track
 from tqdm import tqdm
 
 from top_github_scraper.auth import get_auth
-from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter, isnotebook
+from top_github_scraper.utils import (
+    ScrapeGithubUrl,
+    UserProfileGetter,
+    isnotebook,
+)
 
 
 class RepoScraper:
@@ -165,13 +169,13 @@ def get_top_repo_urls(
     except Exception as e:
         print(e)
         logging.error(
-            """You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
+            """You might be hitting the rate limit of the GitHub API. Have you authenticated your user account?
                       If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available."""
         )
 
 
 def get_top_repos(
-    keyword: int,
+    keyword: str,
     sort_by: str = "best_match",
     save_directory: str = ".",
     max_n_top_contributors: int = 10,
@@ -209,13 +213,13 @@ def get_top_repos(
     except Exception as e:
         print(e)
         logging.error(
-            """You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
+            """You might be hitting the rate limit of the GitHub API. Have you authenticated your user account?
                       If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available."""
         )
 
 
 def get_top_contributors(
-    keyword: int,
+    keyword: str,
     sort_by: str = "best_match",
     max_n_top_contributors: int = 10,
     start_page: int = 1,

--- a/top_github_scraper/scrape_repo.py
+++ b/top_github_scraper/scrape_repo.py
@@ -52,6 +52,15 @@ class RepoScraper:
             logging.error(
                 f"You are getting a bad HTTP response when you are requesting info from this URL: {repo_info_url}"
             )
+            return {
+                "stargazers_count": 0,
+                "forks_count": 0,
+                "contributors": {
+                    "login": [],
+                    "url": [],
+                    "contributions": [],
+                },
+            }
         repo_info = http_response.json()
         info_to_scrape = ["stargazers_count", "forks_count"]
         repo_important_info = {}

--- a/top_github_scraper/scrape_user.py
+++ b/top_github_scraper/scrape_user.py
@@ -1,50 +1,46 @@
 import json
 import os
 from pathlib import Path
-from dotenv import load_dotenv
+
 from rich import print
+
 from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter
 
-load_dotenv()
-
-USERNAME = os.getenv("GITHUB_USERNAME")
-TOKEN = os.getenv("GITHUB_TOKEN")
 
 def get_top_user_urls(
     keyword: str,
-    save_directory: str=".",
+    save_directory: str = ".",
     start_page: int = 1,
     stop_page: int = 50,
 ):
     """Get the URLs of the repositories pop up when searching for a specific
     keyword on GitHub.
-    
+
     See PARAMETERs.md for a description of the parameters of this function
     """
     Path(save_directory).mkdir(parents=True, exist_ok=True)
     save_path = f"{save_directory}/top_repo_urls_{keyword}_{start_page}_{stop_page}.json"
     repo_urls = ScrapeGithubUrl(
-        keyword, 'Users', 'followers', start_page, stop_page
+        keyword, "Users", "followers", start_page, stop_page
     ).scrape_top_repo_url_multiple_pages()
     with open(save_path, "w") as outfile:
         json.dump(repo_urls, outfile)
-    
+
+
 def get_top_users(
     keyword: int,
     start_page: int = 1,
     stop_page: int = 50,
-    save_directory: str="."
+    save_directory: str = ".",
 ):
     """
     Get the information of the owners and contributors of the repositories pop up when searching for a specific
     keyword on GitHub.
-    
+
     See PARAMETERs.md for a description of the parameters of this function.
     """
-    safe_keyword = keyword.replace(" ","_")
-    full_url_save_path = (
-        f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
-    )
+    safe_keyword = keyword.replace(" ", "_")
+    full_url_save_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
     user_save_path = f"{save_directory}/top_user_info_{safe_keyword}_{start_page}_{stop_page}.csv"
     if not Path(full_url_save_path).exists():
         get_top_user_urls(
@@ -55,12 +51,12 @@ def get_top_users(
         )
     with open(full_url_save_path, "r") as infile:
         user_urls = json.load(infile)
-        url = 'https://api.github.com/users'
+        url = "https://api.github.com/users"
         urls = [url + user for user in user_urls]
         for i in range(len(urls)):
             # This is what the HTTP requet needs to be formatted: https://api.github.com/users/ZuzooVn
             # We need to remove the last part of the URL, after the final '/', to use the API correctly.
-            index = urls[i].rfind('/')
+            index = urls[i].rfind("/")
             urls[i] = urls[i][:index]
         top_users = UserProfileGetter(urls).get_all_user_profiles()
         top_users.to_csv(user_save_path)

--- a/top_github_scraper/scrape_user.py
+++ b/top_github_scraper/scrape_user.py
@@ -18,13 +18,15 @@ def get_top_user_urls(
 
     See PARAMETERs.md for a description of the parameters of this function
     """
+    safe_keyword = keyword.replace(" ", "_")
     Path(save_directory).mkdir(parents=True, exist_ok=True)
-    save_path = f"{save_directory}/top_repo_urls_{keyword}_{start_page}_{stop_page}.json"
+    save_path = f"{save_directory}/top_user_urls_{safe_keyword}_{start_page}_{stop_page}.json"
     repo_urls = ScrapeGithubUrl(
         keyword, "Users", "followers", start_page, stop_page
     ).scrape_top_repo_url_multiple_pages()
     with open(save_path, "w") as outfile:
         json.dump(repo_urls, outfile)
+    return repo_urls
 
 
 def get_top_users(
@@ -40,7 +42,7 @@ def get_top_users(
     See PARAMETERs.md for a description of the parameters of this function.
     """
     safe_keyword = keyword.replace(" ", "_")
-    full_url_save_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
+    full_url_save_path = f"{save_directory}/top_user_urls_{safe_keyword}_{start_page}_{stop_page}.json"
     user_save_path = f"{save_directory}/top_user_info_{safe_keyword}_{start_page}_{stop_page}.csv"
     if not Path(full_url_save_path).exists():
         get_top_user_urls(
@@ -53,11 +55,6 @@ def get_top_users(
         user_urls = json.load(infile)
         url = "https://api.github.com/users"
         urls = [url + user for user in user_urls]
-        for i in range(len(urls)):
-            # This is what the HTTP requet needs to be formatted: https://api.github.com/users/ZuzooVn
-            # We need to remove the last part of the URL, after the final '/', to use the API correctly.
-            index = urls[i].rfind("/")
-            urls[i] = urls[i][:index]
         top_users = UserProfileGetter(urls).get_all_user_profiles()
         top_users.to_csv(user_save_path)
         return top_users

--- a/top_github_scraper/scrape_user.py
+++ b/top_github_scraper/scrape_user.py
@@ -28,7 +28,7 @@ def get_top_user_urls(
 
 
 def get_top_users(
-    keyword: int,
+    keyword: str,
     start_page: int = 1,
     stop_page: int = 50,
     save_directory: str = ".",

--- a/top_github_scraper/utils.py
+++ b/top_github_scraper/utils.py
@@ -1,32 +1,23 @@
-from dataclasses import dataclass
-from bs4 import BeautifulSoup
-import requests
-from rich.progress import track
-from rich import print 
-import pandas as pd 
-import os
-import warnings
-from dotenv import load_dotenv
-from typing import List
-from IPython import get_ipython
-from tqdm import tqdm
 import logging
+import warnings
+from dataclasses import dataclass
+from typing import List
 
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from IPython import get_ipython
+from rich import print
+from rich.progress import track
+from tqdm import tqdm
 
-load_dotenv()
+from top_github_scraper.auth import get_auth
+
 warnings.filterwarnings("ignore")
 
-# Currently dead code. To be added later as an enhancement.
-# TYPES = ['Users', 'Repositories', 'Code', 'Commits', 'Issues', 'Packages', 'Topics']
-# SORT_BY = {'Users': ['followers'],'Repositories': ['', 'stars']}
-SCRAPE_CLASS = {'Users': 'mr-1', 'Repositories': "v-align-middle"}
+SCRAPE_CLASS = {"Users": "mr-1", "Repositories": "v-align-middle"}
 
-USERNAME = os.getenv("GITHUB_USERNAME")
-TOKEN = os.getenv("GITHUB_TOKEN")
 
-if USERNAME is None or TOKEN is None:
-    logging.warning("""You are using a Github API as an unauthenticated user. For unauthenticated requests, you are limited to 60 requests per hour.
-     Follow the instruction here to authenticate yourself and increase your API request limit: https://github.com/khuyentran1401/top-github-scraper#setup""")
 class ScrapeGithubUrl:
     """Scrape top Github urls based on a certain keyword and type
 
@@ -36,8 +27,8 @@ class ScrapeGithubUrl:
         keyword to search on Github
     type: str
         whether to search for User or Repositories
-    sort_by: str 
-        sort by best match or most stars, by default 'best_match', which will sort by best match. 
+    sort_by: str
+        sort by best match or most stars, by default 'best_match', which will sort by best match.
         Use 'stars' to sort by most stars.
     start_page_num: int
         page number to start scraping. The default is 0
@@ -49,13 +40,20 @@ class ScrapeGithubUrl:
     List[str]
     """
 
-    def __init__(self,keyword: str, type: str, sort_by: str, start_page_num: int, stop_page_num: int):
+    def __init__(
+        self,
+        keyword: str,
+        type: str,
+        sort_by: str,
+        start_page_num: int,
+        stop_page_num: int,
+    ):
         self.keyword = keyword
         self.type = type
         self.start_page_num = start_page_num
         self.stop_page_num = stop_page_num
-        if sort_by =='best_match':
-            self.sort_by = ''
+        if sort_by == "best_match":
+            self.sort_by = ""
         else:
             self.sort_by = sort_by
 
@@ -67,10 +65,14 @@ class ScrapeGithubUrl:
 
     def _scrape_top_repo_url_one_page(self, page_num: int):
         """Scrape urls of top Github repositories in 1 page"""
-        url = self._keyword_to_url(page_num, self.keyword, type=self.type, sort_by=self.sort_by)
-        page = requests.get(url, auth=(USERNAME, TOKEN))
+        url = self._keyword_to_url(
+            page_num, self.keyword, type=self.type, sort_by=self.sort_by
+        )
+        page = requests.get(url, auth=get_auth())
         if page.status_code != 200:
-            print(f"Bad HTTP Response from: {url}. Got an HTTP repsonse of: {page.status_code}.\n Please confirm this URL is valid.")
+            print(
+                f"Bad HTTP Response from: {url}. Got an HTTP repsonse of: {page.status_code}.\n Please confirm this URL is valid."
+            )
 
         soup = BeautifulSoup(page.text, "html.parser")
         a_tags = soup.find_all("a", class_=SCRAPE_CLASS[self.type])
@@ -87,13 +89,14 @@ class ScrapeGithubUrl:
                 desc="Scraping top GitHub URLs...",
             ):
                 urls.extend(self._scrape_top_repo_url_one_page(page_num))
-        else: 
+        else:
             for page_num in track(
                 range(self.start_page_num, self.stop_page_num),
                 description="Scraping top GitHub URLs...",
             ):
                 urls.extend(self._scrape_top_repo_url_one_page(page_num))
         return urls
+
 
 class UserProfileGetter:
     """Get the information from users' homepage"""
@@ -119,7 +122,7 @@ class UserProfileGetter:
         ]
 
     def _get_one_user_profile(self, profile_url: str):
-        profile = requests.get(profile_url, auth=(USERNAME, TOKEN)).json()
+        profile = requests.get(profile_url, auth=get_auth()).json()
         return {
             key: val
             for key, val in profile.items()
@@ -130,11 +133,11 @@ class UserProfileGetter:
 
         if isnotebook():
             all_contributors = [
-            self._get_one_user_profile(url)
-            for url in tqdm(
-                self.urls, desc="Scraping top GitHub profiles..."
-            )
-        ]
+                self._get_one_user_profile(url)
+                for url in tqdm(
+                    self.urls, desc="Scraping top GitHub profiles..."
+                )
+            ]
         else:
             all_contributors = [
                 self._get_one_user_profile(url)
@@ -152,11 +155,11 @@ class UserProfileGetter:
 def isnotebook():
     try:
         shell = get_ipython().__class__.__name__
-        if shell == 'ZMQInteractiveShell':
-            return True   # Jupyter notebook or qtconsole
-        elif shell == 'TerminalInteractiveShell':
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
             return False  # Terminal running IPython
         else:
             return False  # Other type (?)
     except NameError:
-        return False      # Probably standard Python interpreter
+        return False  # Probably standard Python interpreter

--- a/top_github_scraper/utils.py
+++ b/top_github_scraper/utils.py
@@ -15,7 +15,45 @@ from top_github_scraper.auth import get_auth
 
 warnings.filterwarnings("ignore")
 
-SCRAPE_CLASS = {"Users": "mr-1", "Repositories": "v-align-middle"}
+SKIP_PATHS = {
+    "/search",
+    "/topics",
+    "/settings",
+    "/pricing",
+    "/features",
+    "/enterprise",
+    "/sponsors",
+    "/explore",
+    "/trending",
+    "/marketplace",
+    "/notifications",
+    "/new",
+    "/orgs",
+    "/login",
+    "/signup",
+    "/join",
+    "/security",
+    "/about",
+}
+
+
+def _is_repo_link(href):
+    return (
+        href.startswith("/")
+        and not href.startswith("//")
+        and href.count("/") == 2
+        and not any(href.startswith(s) for s in SKIP_PATHS)
+    )
+
+
+def _is_user_link(href):
+    return (
+        href.startswith("/")
+        and not href.startswith("//")
+        and href.count("/") == 1
+        and len(href) > 1
+        and not any(href.startswith(s) for s in SKIP_PATHS)
+    )
 
 
 class ScrapeGithubUrl:
@@ -75,10 +113,16 @@ class ScrapeGithubUrl:
             )
 
         soup = BeautifulSoup(page.text, "html.parser")
-        a_tags = soup.find_all("a", class_=SCRAPE_CLASS[self.type])
-        urls = [a_tag.get("href") for a_tag in a_tags]
+        a_tags = soup.find_all("a", href=True)
 
-        return urls
+        if self.type == "Repositories":
+            urls = [a.get("href") for a in a_tags if _is_repo_link(a["href"])]
+        elif self.type == "Users":
+            urls = [a.get("href") for a in a_tags if _is_user_link(a["href"])]
+        else:
+            urls = []
+
+        return list(dict.fromkeys(urls))
 
     def scrape_top_repo_url_multiple_pages(self):
         """Scrape urls of top Github repositories in multiple pages"""

--- a/top_github_scraper/utils.py
+++ b/top_github_scraper/utils.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from dataclasses import dataclass
 from typing import List
 
@@ -12,8 +11,6 @@ from rich.progress import track
 from tqdm import tqdm
 
 from top_github_scraper.auth import get_auth
-
-warnings.filterwarnings("ignore")
 
 SKIP_PATHS = {
     "/search",
@@ -63,7 +60,7 @@ class ScrapeGithubUrl:
     -------
     keyword: str
         keyword to search on Github
-    type: str
+    search_type: str
         whether to search for User or Repositories
     sort_by: str
         sort by best match or most stars, by default 'best_match', which will sort by best match.
@@ -81,13 +78,13 @@ class ScrapeGithubUrl:
     def __init__(
         self,
         keyword: str,
-        type: str,
+        search_type: str,
         sort_by: str,
         start_page_num: int,
         stop_page_num: int,
     ):
         self.keyword = keyword
-        self.type = type
+        self.type = search_type
         self.start_page_num = start_page_num
         self.stop_page_num = stop_page_num
         if sort_by == "best_match":
@@ -96,21 +93,24 @@ class ScrapeGithubUrl:
             self.sort_by = sort_by
 
     @staticmethod
-    def _keyword_to_url(page_num: int, keyword: str, type: str, sort_by: str):
+    def _keyword_to_url(
+        page_num: int, keyword: str, search_type: str, sort_by: str
+    ):
         """Change keyword to a url"""
         keyword_no_space = ("+").join(keyword.split(" "))
-        return f"https://github.com/search?o=desc&p={str(page_num)}&q={keyword_no_space}&s={sort_by}&type={type}"
+        return f"https://github.com/search?o=desc&p={str(page_num)}&q={keyword_no_space}&s={sort_by}&type={search_type}"
 
     def _scrape_top_repo_url_one_page(self, page_num: int):
         """Scrape urls of top Github repositories in 1 page"""
         url = self._keyword_to_url(
-            page_num, self.keyword, type=self.type, sort_by=self.sort_by
+            page_num, self.keyword, search_type=self.type, sort_by=self.sort_by
         )
         page = requests.get(url, auth=get_auth())
         if page.status_code != 200:
             print(
-                f"Bad HTTP Response from: {url}. Got an HTTP repsonse of: {page.status_code}.\n Please confirm this URL is valid."
+                f"Bad HTTP Response from: {url}. Got an HTTP response of: {page.status_code}.\n Please confirm this URL is valid."
             )
+            return []
 
         soup = BeautifulSoup(page.text, "html.parser")
         a_tags = soup.find_all("a", href=True)
@@ -145,7 +145,7 @@ class ScrapeGithubUrl:
 class UserProfileGetter:
     """Get the information from users' homepage"""
 
-    def __init__(self, urls: List[str]) -> pd.DataFrame:
+    def __init__(self, urls: List[str]) -> None:
         self.urls = urls
         # Comment out the features that you dont want to show up in the final report.
         self.profile_features = [


### PR DESCRIPTION
## Summary

- **Centralize credentials** into a new `auth.py` module with `gh` CLI fallback — removes duplicated `.env` loading from `utils.py`, `scrape_repo.py`, `scrape_user.py`; supports unauthenticated requests gracefully
- **Fix HTML parsing** for GitHub search results — use explicit link filters (`_is_repo_link`, `_is_user_link`) with a `SKIP_PATHS` allowlist instead of fragile CSS class selectors
- **Fix critical bugs**:
  - Remove broken `rfind` URL truncation in `get_top_users` (#38)
  - Add early return with valid structure on non-200 HTTP in `_get_repo_information` (#39)
  - Fix `get_top_user_urls` missing `safe_keyword` and return statement (#40)
  - Fix cache filename collision between user and repo URL files
  - Add early return on non-200 HTTP in `_scrape_top_repo_url_one_page`
- **Code quality**: remove `warnings.filterwarnings("ignore")`, fix `keyword: int → str` annotations, fix typos (`repsonse→response`, `HitHub→GitHub`), rename shadowed builtin `type→search_type`

## Test plan
- [x] Existing `tests/test_utils.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)